### PR TITLE
Chore: functions only callable by controller | DO NOT MERGE

### DIFF
--- a/pkg/pool-weighted/contracts/smart/IndexPool.sol
+++ b/pkg/pool-weighted/contracts/smart/IndexPool.sol
@@ -97,7 +97,7 @@ contract IndexPool is BaseWeightedPool {
         }
     }
 
-    function reweighTokens(address[] calldata tokens, uint96[] calldata desiredWeights) public {
+    function reweighTokens(address[] calldata tokens, uint96[] calldata desiredWeights) public authenticate {
         uint256 numTokens = tokens.length;
         InputHelpers.ensureInputLengthMatch(numTokens, desiredWeights.length);
 
@@ -112,7 +112,7 @@ contract IndexPool is BaseWeightedPool {
         address[] calldata tokens,
         uint96[] calldata desiredWeights,
         uint256[] calldata minimumBalances
-    ) external {
+    ) external authenticate {
         uint256 numTokens = tokens.length;
         InputHelpers.ensureInputLengthMatch(numTokens, desiredWeights.length, minimumBalances.length);
 

--- a/pkg/pool-weighted/contracts/smart/IndexPool.sol
+++ b/pkg/pool-weighted/contracts/smart/IndexPool.sol
@@ -23,11 +23,23 @@ import "../BaseWeightedPool.sol";
 contract IndexPool is BaseWeightedPool {
     using FixedPoint for uint256;
 
+    /* ==========  Modifiers  ========== */
+
+    modifier _control_ {
+        require(msg.sender == _controller, "ERR_NOT_CONTROLLER");
+        _;
+    }
+
+    /* ==========  Storage  ========== */
+
     uint256 private constant _MAX_TOKENS = 50;
 
     uint256 private immutable _totalTokens;
 
     IERC20[] internal _tokens;
+
+    // Account with CONTROL role.
+    address internal _controller;
 
     // All token balances are normalized to behave as if the token had 18 decimals. We assume a token's decimals will
     // not change throughout its lifetime, and store the corresponding scaling factor for each at construction time.
@@ -88,6 +100,8 @@ contract IndexPool is BaseWeightedPool {
 
         _maxWeightTokenIndex = maxWeightTokenIndex;
 
+        _controller = owner;
+
         _normalizedWeights = normalizedWeights;
         // Immutable variables cannot be initialized inside an if statement, so we must do conditional assignments
         _tokens = tokens;
@@ -97,7 +111,7 @@ contract IndexPool is BaseWeightedPool {
         }
     }
 
-    function reweighTokens(address[] calldata tokens, uint96[] calldata desiredWeights) public authenticate {
+    function reweighTokens(address[] calldata tokens, uint96[] calldata desiredWeights) public _control_ {
         uint256 numTokens = tokens.length;
         InputHelpers.ensureInputLengthMatch(numTokens, desiredWeights.length);
 
@@ -112,7 +126,7 @@ contract IndexPool is BaseWeightedPool {
         address[] calldata tokens,
         uint96[] calldata desiredWeights,
         uint256[] calldata minimumBalances
-    ) external authenticate {
+    ) external _control_ {
         uint256 numTokens = tokens.length;
         InputHelpers.ensureInputLengthMatch(numTokens, desiredWeights.length, minimumBalances.length);
 

--- a/pkg/pool-weighted/test/IndexPool.test.ts
+++ b/pkg/pool-weighted/test/IndexPool.test.ts
@@ -152,7 +152,7 @@ describe('IndexPool', function () {
     });
 
     context('when weights are not normalized', () => {
-      it('reverts: "INPUT_LENGTH_MISMATCH"', async () => {
+      it('reverts: "NORMALIZED_WEIGHT_INVARIANT"', async () => {
         const addresses = allTokens.subset(2).tokens.map((token) => token.address);
         const denormalizedWeights = [fp(0.5), fp(0.3)];
 

--- a/pkg/pool-weighted/test/IndexPool.test.ts
+++ b/pkg/pool-weighted/test/IndexPool.test.ts
@@ -142,12 +142,22 @@ describe('IndexPool', function () {
       pool = await WeightedPool.create(params);
     });
 
+    context('when not called by controller of contract', () => {
+      it('reverts: "ERR_NOT_CONTROLLER"', async () => {
+        const threeAddresses = allTokens.subset(3).tokens.map((token) => token.address);
+        const normalizedWeights = [fp(0.5), fp(0.3), fp(0.2)];
+
+        await expect(pool.reweighTokens(other, threeAddresses, normalizedWeights)).to.be.revertedWith(
+          'ERR_NOT_CONTROLLER'
+        );
+      });
+    });
     context('when input array lengths differ', () => {
       it('reverts: "INPUT_LENGTH_MISMATCH"', async () => {
         const threeAddresses = allTokens.subset(3).tokens.map((token) => token.address);
         const twoWeights = [fp(0.5), fp(0.5)];
 
-        await expect(pool.reweighTokens(threeAddresses, twoWeights)).to.be.revertedWith('INPUT_LENGTH_MISMATCH');
+        await expect(pool.reweighTokens(owner, threeAddresses, twoWeights)).to.be.revertedWith('INPUT_LENGTH_MISMATCH');
       });
     });
 
@@ -156,7 +166,7 @@ describe('IndexPool', function () {
         const addresses = allTokens.subset(2).tokens.map((token) => token.address);
         const denormalizedWeights = [fp(0.5), fp(0.3)];
 
-        await expect(pool.reweighTokens(addresses, denormalizedWeights)).to.be.revertedWith(
+        await expect(pool.reweighTokens(owner, addresses, denormalizedWeights)).to.be.revertedWith(
           'NORMALIZED_WEIGHT_INVARIANT'
         );
       });
@@ -175,13 +185,24 @@ describe('IndexPool', function () {
       pool = await WeightedPool.create(params);
     });
 
+    context('when not called by controller of contract', () => {
+      it('reverts: "ERR_NOT_CONTROLLER"', async () => {
+        const threeAddresses = allTokens.subset(3).tokens.map((token) => token.address);
+        const twoWeights = [fp(0.5), fp(0.5)];
+        const threeMinimumBalances = [1000, 2000, 3000];
+
+        await expect(pool.reindexTokens(other, threeAddresses, twoWeights, threeMinimumBalances)).to.be.revertedWith(
+          'ERR_NOT_CONTROLLER'
+        );
+      });
+    });
     context('when input array lengths differ', () => {
       it('reverts "INPUT_LENGTH_MISMATCH" if lengths of tokens and weights differ', async () => {
         const threeAddresses = allTokens.subset(3).tokens.map((token) => token.address);
         const twoWeights = [fp(0.5), fp(0.5)];
         const threeMinimumBalances = [1000, 2000, 3000];
 
-        await expect(pool.reindexTokens(threeAddresses, twoWeights, threeMinimumBalances)).to.be.revertedWith(
+        await expect(pool.reindexTokens(owner, threeAddresses, twoWeights, threeMinimumBalances)).to.be.revertedWith(
           'INPUT_LENGTH_MISMATCH'
         );
       });
@@ -191,7 +212,7 @@ describe('IndexPool', function () {
         const threeWeights = [fp(0.4), fp(0.5), fp(0.1)];
         const twoMinimumBalances = [1000, 2000];
 
-        await expect(pool.reindexTokens(threeAddresses, threeWeights, twoMinimumBalances)).to.be.revertedWith(
+        await expect(pool.reindexTokens(owner, threeAddresses, threeWeights, twoMinimumBalances)).to.be.revertedWith(
           'INPUT_LENGTH_MISMATCH'
         );
       });
@@ -201,7 +222,7 @@ describe('IndexPool', function () {
         const twoWeights = [fp(0.5), fp(0.5)];
         const threeMinimumBalances = [1000, 2000, 3000];
 
-        await expect(pool.reindexTokens(threeAddresses, twoWeights, threeMinimumBalances)).to.be.revertedWith(
+        await expect(pool.reindexTokens(owner, threeAddresses, twoWeights, threeMinimumBalances)).to.be.revertedWith(
           'INPUT_LENGTH_MISMATCH'
         );
       });
@@ -213,7 +234,7 @@ describe('IndexPool', function () {
         const denormalizedWeights = [fp(0.5), fp(0.3)];
         const minimumBalances = [1000, 2000];
 
-        await expect(pool.reindexTokens(addresses, denormalizedWeights, minimumBalances)).to.be.revertedWith(
+        await expect(pool.reindexTokens(owner, addresses, denormalizedWeights, minimumBalances)).to.be.revertedWith(
           'NORMALIZED_WEIGHT_INVARIANT'
         );
       });
@@ -225,7 +246,7 @@ describe('IndexPool', function () {
         const weights = [fp(0.5), fp(0.5)];
         const invalidMinimumBalances = [1000, 0];
 
-        await expect(pool.reindexTokens(addresses, weights, invalidMinimumBalances)).to.be.revertedWith(
+        await expect(pool.reindexTokens(owner, addresses, weights, invalidMinimumBalances)).to.be.revertedWith(
           'Invalid zero minimum balance'
         );
       });

--- a/pkg/vault/contracts/interfaces/IAuthorizer.sol
+++ b/pkg/vault/contracts/interfaces/IAuthorizer.sol
@@ -23,4 +23,9 @@ interface IAuthorizer {
         address account,
         address where
     ) external view returns (bool);
+
+    /**
+     * @dev Grants multiple roles to a single account.
+     */
+    function grantRoles(bytes32[] memory roles, address account) external;
 }

--- a/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
@@ -50,6 +50,8 @@ import {
 } from './math';
 import { SwapKind, WeightedPoolEncoder } from '@balancer-labs/balancer-js';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { Address } from 'cluster';
+import { ContractType } from 'hardhat/internal/hardhat-network/stack-traces/model';
 
 const MAX_IN_RATIO = fp(0.3);
 const MAX_OUT_RATIO = fp(0.3);
@@ -654,5 +656,15 @@ export default class WeightedPool {
   ): Promise<ContractTransaction> {
     const pool = this.instance.connect(from);
     return await pool.reindexTokens(tokens, normalizedWeights, minimumBalances);
+  }
+
+  async configure(from: SignerWithAddress, controller: any): Promise<ContractTransaction> {
+    console.log('weightedPool: ', from.address);
+    const pool = this.instance.connect(from);
+    return await pool.configure(controller);
+  }
+
+  async getController(): Promise<ContractTransaction> {
+    return await this.instance.controller();
   }
 }

--- a/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
@@ -637,15 +637,22 @@ export default class WeightedPool {
     return { amounts: result.collectedFees, tokenAddresses: result.tokens };
   }
 
-  async reweighTokens(tokens: string[], normalizedWeights: BigNumberish[]): Promise<ContractTransaction> {
-    return await this.instance.reweighTokens(tokens, normalizedWeights);
+  async reweighTokens(
+    from: SignerWithAddress,
+    tokens: string[],
+    normalizedWeights: BigNumberish[]
+  ): Promise<ContractTransaction> {
+    const pool = this.instance.connect(from);
+    return await pool.reweighTokens(tokens, normalizedWeights);
   }
 
   async reindexTokens(
+    from: SignerWithAddress,
     tokens: string[],
     normalizedWeights: BigNumberish[],
     minimumBalances: BigNumberish[]
   ): Promise<ContractTransaction> {
-    return await this.instance.reindexTokens(tokens, normalizedWeights, minimumBalances);
+    const pool = this.instance.connect(from);
+    return await pool.reindexTokens(tokens, normalizedWeights, minimumBalances);
   }
 }


### PR DESCRIPTION
## What have I done?

- add `_control_` modifier to functions `reweighTokens()` and `reindexTokens()`
- add `controller` state variable to the contract
- add ability to parse sender while testing in `WeightedPool.ts`
- add tests

## This PR implements:
- #16 

closes #16 