### PR TITLE
Feature: Chore functions only callable by controller

### DIFF
--- a/pkg/pool-weighted/contracts/smart/IndexPool.sol
+++ b/pkg/pool-weighted/contracts/smart/IndexPool.sol
@@ -82,7 +82,7 @@ contract IndexPool is BaseWeightedPool, ReentrancyGuard {
         uint256 swapFeePercentage,
         uint256 pauseWindowDuration,
         uint256 bufferPeriodDuration,
-        address owner
+        address controller
     )
         BaseWeightedPool(
             vault,
@@ -93,7 +93,7 @@ contract IndexPool is BaseWeightedPool, ReentrancyGuard {
             swapFeePercentage,
             pauseWindowDuration,
             bufferPeriodDuration,
-            owner
+            controller
         )
     {
         uint256 numTokens = tokens.length;

--- a/pkg/pool-weighted/contracts/smart/IndexPool.sol
+++ b/pkg/pool-weighted/contracts/smart/IndexPool.sol
@@ -68,7 +68,7 @@ contract IndexPool is BaseWeightedPool, ReentrancyGuard {
         uint256 swapFeePercentage;
         uint256 pauseWindowDuration;
         uint256 bufferPeriodDuration;
-        address owner;
+        address controller;
     }
 
     constructor(NewPoolParams memory params)
@@ -81,7 +81,7 @@ contract IndexPool is BaseWeightedPool, ReentrancyGuard {
             params.swapFeePercentage,
             params.pauseWindowDuration,
             params.bufferPeriodDuration,
-            params.owner
+            params.controller
         )
     {
         uint256 numTokens = params.tokens.length;

--- a/pkg/pool-weighted/contracts/smart/IndexPool.sol
+++ b/pkg/pool-weighted/contracts/smart/IndexPool.sol
@@ -212,7 +212,7 @@ contract IndexPool is BaseWeightedPool, ReentrancyGuard {
         _startGradualWeightChange(startTime, endTime, _getNormalizedWeights(), endWeights, tokens);
     }
 
-    function reweighTokens(address[] calldata tokens, uint256[] calldata desiredWeights) public {
+    function reweighTokens(address[] calldata tokens, uint256[] calldata desiredWeights) public authenticate {
         uint256 endTime = _getMiscData().decodeUint32(_END_TIME_OFFSET);
         require(block.timestamp >= endTime, "Weight change is already in process");
         uint256 diff = 0;
@@ -243,7 +243,7 @@ contract IndexPool is BaseWeightedPool, ReentrancyGuard {
         address[] calldata tokens,
         uint256[] calldata desiredWeights,
         uint256[] calldata minimumBalances
-    ) external pure {
+    ) external authenticate {
         uint256 numTokens = tokens.length;
         InputHelpers.ensureInputLengthMatch(numTokens, desiredWeights.length, minimumBalances.length);
 

--- a/pkg/pool-weighted/contracts/smart/IndexPool.sol
+++ b/pkg/pool-weighted/contracts/smart/IndexPool.sol
@@ -30,7 +30,6 @@ contract IndexPool is BaseWeightedPool, ReentrancyGuard {
 
     uint256 private constant _MAX_TOKENS = 50;
 
-
     // For gas optimization, store start/end weights and timestamps in one bytes32
     // Start weights need to be high precision, since restarting the update resets them to "spot"
     // values. Target end weights do not need as much precision.
@@ -57,7 +56,6 @@ contract IndexPool is BaseWeightedPool, ReentrancyGuard {
     uint256 private constant _DECIMAL_DIFF_OFFSET = 96;
 
     uint256 private constant _SECONDS_IN_A_DAY = 86400;
-
 
     uint256 private immutable _totalTokens;
 
@@ -139,25 +137,25 @@ contract IndexPool is BaseWeightedPool, ReentrancyGuard {
      * Current weights should be retrieved via `getNormalizedWeights()`.
      */
     function getGradualWeightUpdateParams()
-    external
-    view
-    returns (
-        uint256 startTime,
-        uint256 endTime,
-        uint256[] memory endWeights
-    )
+        external
+        view
+        returns (
+            uint256 startTime,
+            uint256 endTime,
+            uint256[] memory endWeights
+        )
     {
-            // Load current pool state from storage
-            bytes32 poolState = _poolState;
+        // Load current pool state from storage
+        bytes32 poolState = _poolState;
 
-            startTime = poolState.decodeUint32(_START_TIME_OFFSET);
-            endTime = poolState.decodeUint32(_END_TIME_OFFSET);
-            uint256 totalTokens = _getTotalTokens();
-            endWeights = new uint256[](totalTokens);
+        startTime = poolState.decodeUint32(_START_TIME_OFFSET);
+        endTime = poolState.decodeUint32(_END_TIME_OFFSET);
+        uint256 totalTokens = _getTotalTokens();
+        endWeights = new uint256[](totalTokens);
 
-            for (uint256 i = 0; i < totalTokens; i++) {
-                endWeights[i] =  _tokenState[_tokens[i]].decodeUint32(_END_WEIGHT_OFFSET).uncompress32();
-            }
+        for (uint256 i = 0; i < totalTokens; i++) {
+            endWeights[i] = _tokenState[_tokens[i]].decodeUint32(_END_WEIGHT_OFFSET).uncompress32();
+        }
     }
 
     /**
@@ -184,9 +182,9 @@ contract IndexPool is BaseWeightedPool, ReentrancyGuard {
     }
 
     /**
-    * @dev When calling updateWeightsGradually again during an update, reset the start weights to the current weights,
-    * if necessary.
-    */
+     * @dev When calling updateWeightsGradually again during an update, reset the start weights to the current weights,
+     * if necessary.
+     */
     function _startGradualWeightChange(
         uint256 startTime,
         uint256 endTime,
@@ -201,9 +199,9 @@ contract IndexPool is BaseWeightedPool, ReentrancyGuard {
             _require(endWeight >= _MIN_WEIGHT, Errors.MIN_WEIGHT);
 
             _tokenState[_tokens[i]] = _tokenState[_tokens[i]]
-            .insertUint64(startWeights[i].compress64(), _START_WEIGHT_OFFSET )
-            .insertUint32(endWeight.compress32(), _END_WEIGHT_OFFSET)
-            .insertUint5(uint256(18).sub(ERC20(address(_tokens[i])).decimals()), _DECIMAL_DIFF_OFFSET);
+                .insertUint64(startWeights[i].compress64(), _START_WEIGHT_OFFSET)
+                .insertUint32(endWeight.compress32(), _END_WEIGHT_OFFSET)
+                .insertUint5(uint256(18).sub(ERC20(address(_tokens[i])).decimals()), _DECIMAL_DIFF_OFFSET);
 
             normalizedSum = normalizedSum.add(endWeight);
         }
@@ -214,7 +212,6 @@ contract IndexPool is BaseWeightedPool, ReentrancyGuard {
 
         //        emit GradualWeightUpdateScheduled(startTime, endTime, startWeights, endWeights);
     }
-
 
     /**
      * @dev Schedule a gradual weight change, from the current weights to the given endWeights,
@@ -238,23 +235,21 @@ contract IndexPool is BaseWeightedPool, ReentrancyGuard {
         _startGradualWeightChange(startTime, endTime, _getNormalizedWeights(), endWeights);
     }
 
-
-    function reweighTokens(address[] calldata tokens, uint256[] calldata desiredWeights) public{
+    function reweighTokens(address[] calldata tokens, uint256[] calldata desiredWeights) public authenticate {
         uint256 endTime = _poolState.decodeUint32(_END_TIME_OFFSET);
-        require(block.timestamp >= endTime ,"Weight change is already in process");
+        require(block.timestamp >= endTime, "Weight change is already in process");
         uint256 diff = 0;
         uint256 numTokens = tokens.length;
         InputHelpers.ensureInputLengthMatch(numTokens, desiredWeights.length);
 
         uint256 normalizedSum = 0;
         for (uint8 i = 0; i < numTokens; i++) {
-            if(desiredWeights[i] > _normalizedWeights[i]){
-                if(diff < desiredWeights[i].sub(_normalizedWeights[i])){
+            if (desiredWeights[i] > _normalizedWeights[i]) {
+                if (diff < desiredWeights[i].sub(_normalizedWeights[i])) {
                     diff = desiredWeights[i].sub(_normalizedWeights[i]);
                 }
-            }
-            else {
-                if(diff < _normalizedWeights[i].sub(desiredWeights[i])){
+            } else {
+                if (diff < _normalizedWeights[i].sub(desiredWeights[i])) {
                     diff = _normalizedWeights[i].sub(desiredWeights[i]);
                 }
             }
@@ -269,7 +264,7 @@ contract IndexPool is BaseWeightedPool, ReentrancyGuard {
         address[] calldata tokens,
         uint256[] calldata desiredWeights,
         uint256[] calldata minimumBalances
-    ) external {
+    ) external view authenticate {
         uint256 numTokens = tokens.length;
         InputHelpers.ensureInputLengthMatch(numTokens, desiredWeights.length, minimumBalances.length);
 
@@ -298,16 +293,14 @@ contract IndexPool is BaseWeightedPool, ReentrancyGuard {
         }
     }
 
-
     function _getNormalizedWeightByIndex(uint256 i, bytes32 poolState) internal view returns (uint256) {
-        uint256 startWeight =  _tokenState[_tokens[i]].decodeUint64(_START_WEIGHT_OFFSET).uncompress64();
-        uint256 endWeight =  _tokenState[_tokens[i]].decodeUint32(_END_WEIGHT_OFFSET).uncompress32();
+        uint256 startWeight = _tokenState[_tokens[i]].decodeUint64(_START_WEIGHT_OFFSET).uncompress64();
+        uint256 endWeight = _tokenState[_tokens[i]].decodeUint32(_END_WEIGHT_OFFSET).uncompress32();
 
         uint256 pctProgress = _calculateWeightChangeProgress(poolState);
 
         return _interpolateWeight(startWeight, endWeight, pctProgress);
     }
-
 
     function _getNormalizedWeight(IERC20 token) internal view virtual override returns (uint256) {
         // prettier-ignore
@@ -319,21 +312,18 @@ contract IndexPool is BaseWeightedPool, ReentrancyGuard {
         _revert(Errors.INVALID_TOKEN);
     }
 
-
     function _getNormalizedWeights() internal view override returns (uint256[] memory) {
         uint256 totalTokens = _getTotalTokens();
         uint256[] memory normalizedWeights = new uint256[](totalTokens);
 
         bytes32 poolState = _poolState;
 
-        for( uint8 i = 0; i < totalTokens; i++)
-        {
+        for (uint8 i = 0; i < totalTokens; i++) {
             normalizedWeights[i] = _getNormalizedWeightByIndex(i, poolState);
         }
 
         return normalizedWeights;
     }
-
 
     function _getNormalizedWeightsAndMaxWeightIndex()
         internal
@@ -370,5 +360,12 @@ contract IndexPool is BaseWeightedPool, ReentrancyGuard {
 
     function _scalingFactors() internal view virtual override returns (uint256[] memory) {
         return scalingFactors;
+    }
+
+    function _isOwnerOnlyAction(bytes32 actionId) internal view virtual override returns (bool) {
+        return
+            (actionId == getActionId(this.reindexTokens.selector)) ||
+            (actionId == getActionId(this.reweighTokens.selector)) ||
+            super._isOwnerOnlyAction(actionId);
     }
 }

--- a/pkg/pool-weighted/contracts/smart/IndexPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/smart/IndexPoolFactory.sol
@@ -43,19 +43,19 @@ contract IndexPoolFactory is BasePoolSplitCodeFactory, FactoryWidePauseWindow {
         (uint256 pauseWindowDuration, uint256 bufferPeriodDuration) = getPauseConfiguration();
 
         return
-        _create(
-            abi.encode(
-                getVault(),
-                name,
-                symbol,
-                tokens,
-                weights,
-                swapFeePercentage,
-                pauseWindowDuration,
-                bufferPeriodDuration,
-                owner,
-                swapEnabledOnStart
-            )
-        );
+            _create(
+                abi.encode(
+                    getVault(),
+                    name,
+                    symbol,
+                    tokens,
+                    weights,
+                    swapFeePercentage,
+                    pauseWindowDuration,
+                    bufferPeriodDuration,
+                    owner,
+                    swapEnabledOnStart
+                )
+            );
     }
 }

--- a/pkg/pool-weighted/contracts/smart/IndexPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/smart/IndexPoolFactory.sol
@@ -36,7 +36,7 @@ contract IndexPoolFactory is BasePoolSplitCodeFactory, FactoryWidePauseWindow {
         IERC20[] memory tokens,
         uint256[] memory weights,
         uint256 swapFeePercentage,
-        address owner,
+        address controller,
         bool swapEnabledOnStart
     ) external returns (address) {
         (uint256 pauseWindowDuration, uint256 bufferPeriodDuration) = getPauseConfiguration();
@@ -52,7 +52,7 @@ contract IndexPoolFactory is BasePoolSplitCodeFactory, FactoryWidePauseWindow {
                     swapFeePercentage,
                     pauseWindowDuration,
                     bufferPeriodDuration,
-                    owner,
+                    controller,
                     swapEnabledOnStart
                 )
             );

--- a/pkg/pool-weighted/contracts/smart/IndexPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/smart/IndexPoolFactory.sol
@@ -36,7 +36,7 @@ contract IndexPoolFactory is BasePoolSplitCodeFactory, FactoryWidePauseWindow {
         IERC20[] memory tokens,
         uint256[] memory weights,
         uint256 swapFeePercentage,
-        address owner,
+        address controller,
         bool swapEnabledOnStart,
         uint256 managementSwapFeePercentage
     ) external returns (address) {
@@ -53,7 +53,7 @@ contract IndexPoolFactory is BasePoolSplitCodeFactory, FactoryWidePauseWindow {
                     swapFeePercentage,
                     pauseWindowDuration,
                     bufferPeriodDuration,
-                    owner,
+                    controller,
                     swapEnabledOnStart
                 )
             );

--- a/pkg/pool-weighted/contracts/utils/IndexPoolUtils.sol
+++ b/pkg/pool-weighted/contracts/utils/IndexPoolUtils.sol
@@ -70,10 +70,11 @@ contract IndexPoolUtils {
             checksum = Math.add(checksum, normalizedWeights[i]);
         }
 
-        // there are cases where due to rounding the sum of all normalizedWeights is slightly less/more than HUNDRED_PERCENT
-        // the largest possible deviation I could observe was 19 (e.g. 1000000000000000019)
-        // in that case we remove/add the diff from the first weight to ensure normalized weights
-        // since this diff is extremely small (< 0.000000000001 %) this shouldn't pose a risk
+        // there are cases where due to rounding the sum of all normalizedWeights is slightly
+        // less/more than HUNDRED_PERCENT the largest possible deviation I could observe was 19
+        // (e.g. 1000000000000000019) in that case we remove/add the diff from the first weight to
+        // ensure normalized weights since this diff is extremely small (< 0.000000000001 %)
+        // this shouldn't pose a risk
         if (checksum != HUNDRED_PERCENT) {
             normalizedWeights[0] = checksum > HUNDRED_PERCENT
                 ? Math.sub(normalizedWeights[0], (checksum - HUNDRED_PERCENT))

--- a/pkg/pool-weighted/test/IndexPool.test.ts
+++ b/pkg/pool-weighted/test/IndexPool.test.ts
@@ -27,10 +27,11 @@ const getTimeForWeightChange = (weightDifference: number) => {
 };
 
 describe('IndexPool', function () {
-  let controller: SignerWithAddress, other: SignerWithAddress, vault: Vault;
+  let owner: SignerWithAddress, controller: SignerWithAddress, other: SignerWithAddress, vault: Vault;
 
   before('setup signers', async () => {
-    [, controller, other] = await ethers.getSigners();
+    [, owner, other] = await ethers.getSigners();
+    controller = owner;
   });
 
   const MAX_TOKENS = 4;

--- a/pkg/pool-weighted/test/IndexPool.test.ts
+++ b/pkg/pool-weighted/test/IndexPool.test.ts
@@ -26,7 +26,7 @@ const getTimeForWeightChange = (weightDifference: number) => {
   return (weightDifference / 1e18) * 86400 * 100;
 };
 
-describe.only('IndexPool', function () {
+describe('IndexPool', function () {
   let owner: SignerWithAddress, other: SignerWithAddress;
 
   before('setup signers', async () => {

--- a/pkg/pool-weighted/test/IndexPool.test.ts
+++ b/pkg/pool-weighted/test/IndexPool.test.ts
@@ -27,10 +27,10 @@ const getTimeForWeightChange = (weightDifference: number) => {
 };
 
 describe('IndexPool', function () {
-  let owner: SignerWithAddress, other: SignerWithAddress;
+  let controller: SignerWithAddress, other: SignerWithAddress;
 
   before('setup signers', async () => {
-    [, owner, other] = await ethers.getSigners();
+    [, controller, other] = await ethers.getSigners();
   });
 
   const MAX_TOKENS = 4;
@@ -53,7 +53,7 @@ describe('IndexPool', function () {
       const params = {
         tokens: allTokens.subset(1),
         weights: [fp(0.3)],
-        owner,
+        owner: controller,
         poolType: WeightedPoolType.INDEX_POOL,
       };
       await expect(WeightedPool.create(params)).to.be.revertedWith('MIN_TOKENS');
@@ -63,7 +63,7 @@ describe('IndexPool', function () {
       const params = {
         tokens,
         weights: tooManyWeights,
-        owner,
+        owner: controller,
         poolType: WeightedPoolType.INDEX_POOL,
       };
       await expect(WeightedPool.create(params)).to.be.revertedWith('INPUT_LENGTH_MISMATCH');
@@ -109,7 +109,7 @@ describe('IndexPool', function () {
       const params = {
         tokens,
         weights,
-        owner,
+        owner: controller,
         poolType: WeightedPoolType.INDEX_POOL,
         fromFactory: true,
       };
@@ -130,7 +130,7 @@ describe('IndexPool', function () {
         const params = {
           tokens,
           weights,
-          owner,
+          owner: controller,
           poolType: WeightedPoolType.INDEX_POOL,
           swapEnabledOnStart: false,
         };
@@ -148,14 +148,14 @@ describe('IndexPool', function () {
       const params = {
         tokens,
         weights,
-        owner,
+        owner: controller,
         poolType: WeightedPoolType.INDEX_POOL,
         swapEnabledOnStart: false,
       };
       pool = await WeightedPool.create(params);
     });
 
-    context('when not called by the owner', () => {
+    context('when not called by the controller', () => {
       it('reverts: "BAL#401 (SENDER_NOT_ALLOWED)"', async () => {
         const threeAddresses = allTokens.subset(3).tokens.map((token) => token.address);
         const twoWeights = [fp(0.5), fp(0.5)];
@@ -168,7 +168,9 @@ describe('IndexPool', function () {
         const threeAddresses = allTokens.subset(3).tokens.map((token) => token.address);
         const twoWeights = [fp(0.5), fp(0.5)];
 
-        await expect(pool.reweighTokens(owner, threeAddresses, twoWeights)).to.be.revertedWith('INPUT_LENGTH_MISMATCH');
+        await expect(pool.reweighTokens(controller, threeAddresses, twoWeights)).to.be.revertedWith(
+          'INPUT_LENGTH_MISMATCH'
+        );
       });
     });
 
@@ -177,7 +179,7 @@ describe('IndexPool', function () {
         const addresses = allTokens.subset(2).tokens.map((token) => token.address);
         const denormalizedWeights = [fp(0.5), fp(0.3)];
 
-        await expect(pool.reweighTokens(owner, addresses, denormalizedWeights)).to.be.revertedWith(
+        await expect(pool.reweighTokens(controller, addresses, denormalizedWeights)).to.be.revertedWith(
           'NORMALIZED_WEIGHT_INVARIANT'
         );
       });
@@ -188,7 +190,7 @@ describe('IndexPool', function () {
 
       sharedBeforeEach('deploy pool', async () => {
         await pool.reweighTokens(
-          owner,
+          controller,
           allTokens.subset(4).tokens.map((token) => token.address),
           desiredWeights
         );
@@ -214,14 +216,14 @@ describe('IndexPool', function () {
       const params = {
         tokens,
         weights,
-        owner,
+        owner: controller,
         poolType: WeightedPoolType.INDEX_POOL,
         swapEnabledOnStart: false,
       };
       pool = await WeightedPool.create(params);
     });
 
-    context('when not called by the owner', () => {
+    context('when not called by the controller', () => {
       it('reverts: ""BAL#401 (SENDER_NOT_ALLOWED)"', async () => {
         const threeAddresses = allTokens.subset(3).tokens.map((token) => token.address);
         const twoWeights = [fp(0.5), fp(0.5)];
@@ -239,9 +241,9 @@ describe('IndexPool', function () {
         const twoWeights = [fp(0.5), fp(0.5)];
         const threeMinimumBalances = [1000, 2000, 3000];
 
-        await expect(pool.reindexTokens(owner, threeAddresses, twoWeights, threeMinimumBalances)).to.be.revertedWith(
-          'INPUT_LENGTH_MISMATCH'
-        );
+        await expect(
+          pool.reindexTokens(controller, threeAddresses, twoWeights, threeMinimumBalances)
+        ).to.be.revertedWith('INPUT_LENGTH_MISMATCH');
       });
 
       it('reverts "INPUT_LENGTH_MISMATCH" if lengths of tokens and minimum balances differ', async () => {
@@ -249,9 +251,9 @@ describe('IndexPool', function () {
         const threeWeights = [fp(0.4), fp(0.5), fp(0.1)];
         const twoMinimumBalances = [1000, 2000];
 
-        await expect(pool.reindexTokens(owner, threeAddresses, threeWeights, twoMinimumBalances)).to.be.revertedWith(
-          'INPUT_LENGTH_MISMATCH'
-        );
+        await expect(
+          pool.reindexTokens(controller, threeAddresses, threeWeights, twoMinimumBalances)
+        ).to.be.revertedWith('INPUT_LENGTH_MISMATCH');
       });
 
       it('reverts "INPUT_LENGTH_MISMATCH" if lengths of weights and minimum balances differ', async () => {
@@ -259,9 +261,9 @@ describe('IndexPool', function () {
         const twoWeights = [fp(0.5), fp(0.5)];
         const threeMinimumBalances = [1000, 2000, 3000];
 
-        await expect(pool.reindexTokens(owner, threeAddresses, twoWeights, threeMinimumBalances)).to.be.revertedWith(
-          'INPUT_LENGTH_MISMATCH'
-        );
+        await expect(
+          pool.reindexTokens(controller, threeAddresses, twoWeights, threeMinimumBalances)
+        ).to.be.revertedWith('INPUT_LENGTH_MISMATCH');
       });
     });
 
@@ -271,9 +273,9 @@ describe('IndexPool', function () {
         const denormalizedWeights = [fp(0.5), fp(0.3)];
         const minimumBalances = [1000, 2000];
 
-        await expect(pool.reindexTokens(owner, addresses, denormalizedWeights, minimumBalances)).to.be.revertedWith(
-          'NORMALIZED_WEIGHT_INVARIANT'
-        );
+        await expect(
+          pool.reindexTokens(controller, addresses, denormalizedWeights, minimumBalances)
+        ).to.be.revertedWith('NORMALIZED_WEIGHT_INVARIANT');
       });
     });
 
@@ -283,7 +285,7 @@ describe('IndexPool', function () {
         const weights = [fp(0.5), fp(0.5)];
         const invalidMinimumBalances = [1000, 0];
 
-        await expect(pool.reindexTokens(owner, addresses, weights, invalidMinimumBalances)).to.be.revertedWith(
+        await expect(pool.reindexTokens(controller, addresses, weights, invalidMinimumBalances)).to.be.revertedWith(
           'Invalid zero minimum balance'
         );
       });

--- a/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
@@ -50,6 +50,8 @@ import {
 } from './math';
 import { SwapKind, WeightedPoolEncoder } from '@balancer-labs/balancer-js';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { Address } from 'cluster';
+import { ContractType } from 'hardhat/internal/hardhat-network/stack-traces/model';
 
 const MAX_IN_RATIO = fp(0.3);
 const MAX_OUT_RATIO = fp(0.3);
@@ -637,15 +639,22 @@ export default class WeightedPool {
     return { amounts: result.collectedFees, tokenAddresses: result.tokens };
   }
 
-  async reweighTokens(tokens: string[], normalizedWeights: BigNumberish[]): Promise<ContractTransaction> {
-    return await this.instance.reweighTokens(tokens, normalizedWeights);
+  async reweighTokens(
+    from: SignerWithAddress,
+    tokens: string[],
+    normalizedWeights: BigNumberish[]
+  ): Promise<ContractTransaction> {
+    const pool = this.instance.connect(from);
+    return await pool.reweighTokens(tokens, normalizedWeights);
   }
 
   async reindexTokens(
+    from: SignerWithAddress,
     tokens: string[],
     normalizedWeights: BigNumberish[],
     minimumBalances: BigNumberish[]
   ): Promise<ContractTransaction> {
-    return await this.instance.reindexTokens(tokens, normalizedWeights, minimumBalances);
+    const pool = this.instance.connect(from);
+    return await pool.reindexTokens(tokens, normalizedWeights, minimumBalances);
   }
 }

--- a/pvt/helpers/src/models/pools/weighted/WeightedPoolDeployer.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPoolDeployer.ts
@@ -138,7 +138,7 @@ export default {
               assetManagers: assetManagers,
               pauseWindowDuration: pauseWindowDuration,
               bufferPeriodDuration: bufferPeriodDuration,
-              owner: TypesConverter.toAddress(owner),
+              controller: TypesConverter.toAddress(owner),
             },
           ],
           from,


### PR DESCRIPTION
## What did I do?

- add `authenticate` modifier to functions that should only be accessed by the `owner`
- add function `_isOwnerOnlyAction` to add the `actionID` of the functions we want to restrict to `onlyOwnerAccess`
- add the possibility to send transactions to the contract from specific addresses inside `WeightedPool.ts`
- renamed `owner` to `controller`
- write test

## This PR implements issues:
- #16


closes #16 