### PR TITLE
Chore: Test cases for swap, join, exit

### DIFF
--- a/pkg/pool-weighted/test/IndexPool.test.ts
+++ b/pkg/pool-weighted/test/IndexPool.test.ts
@@ -344,7 +344,7 @@ describe('IndexPool', function () {
     });
   });
 
-  describe.only('basic vault interactions', () => {
+  describe('basic vault interactions', () => {
     const numberExistingTokens = 3;
     const originalWeights = [fp(0.4), fp(0.3), fp(0.3)];
     const initialPoolAmounts = fp(1);

--- a/pkg/pool-weighted/test/IndexPool.test.ts
+++ b/pkg/pool-weighted/test/IndexPool.test.ts
@@ -364,7 +364,7 @@ describe('IndexPool', function () {
 
     const limit = 0; // Minimum amount out
     const deadline = MAX_UINT256;
-    let poolId: string, singleSwap: SingleSwap, funds: FundManagement, limit: number, deadline: BigNumber, vault: Vault;
+    let poolId: string, singleSwap: SingleSwap, funds: FundManagement, vault: Vault;
 
     describe('swapping', () => {
       sharedBeforeEach('deploy pool', async () => {

--- a/pkg/pool-weighted/test/IndexPool.test.ts
+++ b/pkg/pool-weighted/test/IndexPool.test.ts
@@ -8,6 +8,7 @@ import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 import WeightedPool from '@balancer-labs/v2-helpers/src/models/pools/weighted/WeightedPool';
 import { range } from 'lodash';
 import { WeightedPoolType } from '../../../pvt/helpers/src/models/pools/weighted/types';
+import { MAX_UINT256, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 
 import {
   BatchSwapStep,
@@ -361,15 +362,11 @@ describe('IndexPool', function () {
     const initialBalances = Array(numberExistingTokens).fill(fp(1));
     const minimumBalances = new Array(numberExistingTokens + numberNewTokens).fill(standardMinimumBalance);
 
-    let reindexTokens: string[],
-      poolId: string,
-      singleSwap: SingleSwap,
-      funds: FundManagement,
-      limit: number,
-      deadline: BigNumber,
-      vault: Vault;
+    const limit = 0; // Minimum amount out
+    const deadline = MAX_UINT256;
+    let poolId: string, singleSwap: SingleSwap, funds: FundManagement, limit: number, deadline: BigNumber, vault: Vault;
 
-    describe('joining', () => {
+    describe('swapping', () => {
       sharedBeforeEach('deploy pool', async () => {
         vault = await Vault.create();
         const params = {
@@ -389,8 +386,26 @@ describe('IndexPool', function () {
         await pool.init({ from: owner, initialBalances });
       });
 
-      it.only('lol', () => {
-        console.log('kek');
+      sharedBeforeEach('swap', async () => {
+        poolId = await pool.getPoolId();
+        singleSwap = {
+          poolId,
+          kind: SwapKind.GivenIn,
+          assetIn: allTokens.first.address,
+          assetOut: allTokens.second.address,
+          amount: fp(0.0001),
+          userData: '0x',
+        };
+        funds = {
+          sender: owner.address,
+          fromInternalBalance: false,
+          recipient: other.address,
+          toInternalBalance: false,
+        };
+      });
+
+      it.only('lol', async () => {
+        await vault.instance.connect(owner).swap(singleSwap, funds, limit, deadline);
       });
     });
   });

--- a/pkg/pool-weighted/test/IndexPool.test.ts
+++ b/pkg/pool-weighted/test/IndexPool.test.ts
@@ -353,17 +353,14 @@ describe('IndexPool', function () {
   });
 
   describe('basic vault interactions', () => {
-    const numberNewTokens = 1;
     const numberExistingTokens = 3;
-    const newTokenTargetWeight = fp(0.1);
     const originalWeights = [fp(0.4), fp(0.3), fp(0.3)];
-    const reindexWeights = [fp(0.5), fp(0.2), fp(0.2), newTokenTargetWeight];
-    const standardMinimumBalance = fp(0.01);
-    const initialBalances = Array(numberExistingTokens).fill(fp(1));
-    const minimumBalances = new Array(numberExistingTokens + numberNewTokens).fill(standardMinimumBalance);
-
+    const initialPoolAmounts = fp(1);
+    const initialBalances = Array(numberExistingTokens).fill(initialPoolAmounts);
     const limit = 0; // Minimum amount out
     const deadline = MAX_UINT256;
+    const swapAmount = fp(0.0001);
+
     let poolId: string, singleSwap: SingleSwap, funds: FundManagement, vault: Vault;
 
     describe('swapping', () => {
@@ -393,7 +390,7 @@ describe('IndexPool', function () {
           kind: SwapKind.GivenIn,
           assetIn: allTokens.first.address,
           assetOut: allTokens.second.address,
-          amount: fp(0.0001),
+          amount: swapAmount,
           userData: '0x',
         };
         funds = {
@@ -402,10 +399,12 @@ describe('IndexPool', function () {
           recipient: other.address,
           toInternalBalance: false,
         };
+        await vault.instance.connect(owner).swap(singleSwap, funds, limit, deadline);
       });
 
-      it.only('lol', async () => {
-        await vault.instance.connect(owner).swap(singleSwap, funds, limit, deadline);
+      it('adds tokens of type assetIn to the vault', async () => {
+        const difference = (await tokens.first.balanceOf(vault.address)).sub(initialPoolAmounts);
+        expect(difference).to.equal(swapAmount);
       });
     });
   });

--- a/pkg/pool-weighted/test/IndexPool.test.ts
+++ b/pkg/pool-weighted/test/IndexPool.test.ts
@@ -1,23 +1,15 @@
 import { ethers } from 'hardhat';
 import { expect } from 'chai';
 import { BigNumber } from 'ethers';
+import { range } from 'lodash';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
-import { fp } from '@balancer-labs/v2-helpers/src/numbers';
+import { fp, pct } from '@balancer-labs/v2-helpers/src/numbers';
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 import WeightedPool from '@balancer-labs/v2-helpers/src/models/pools/weighted/WeightedPool';
-import { range } from 'lodash';
+import { MAX_UINT256 } from '@balancer-labs/v2-helpers/src/constants';
+import { FundManagement, SingleSwap, SwapKind } from '@balancer-labs/balancer-js';
 import { WeightedPoolType } from '../../../pvt/helpers/src/models/pools/weighted/types';
-import { MAX_UINT256, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
-
-import {
-  BatchSwapStep,
-  FundManagement,
-  SingleSwap,
-  SwapKind,
-  PoolSpecialization,
-  RelayerAuthorization,
-} from '@balancer-labs/balancer-js';
 
 const calculateMaxWeightDifference = (oldWeights: BigNumber[], newWeights: BigNumber[]) => {
   let maxWeightDifference = 0;
@@ -352,7 +344,7 @@ describe('IndexPool', function () {
     });
   });
 
-  describe('basic vault interactions', () => {
+  describe.only('basic vault interactions', () => {
     const numberExistingTokens = 3;
     const originalWeights = [fp(0.4), fp(0.3), fp(0.3)];
     const initialPoolAmounts = fp(1);
@@ -363,32 +355,32 @@ describe('IndexPool', function () {
 
     let poolId: string, singleSwap: SingleSwap, funds: FundManagement, vault: Vault;
 
+    sharedBeforeEach('deploy pool', async () => {
+      vault = await Vault.create();
+      const params = {
+        tokens: tokens.subset(numberExistingTokens),
+        weights: originalWeights,
+        owner,
+        poolType: WeightedPoolType.INDEX_POOL,
+        fromFactory: true,
+        vault,
+      };
+      pool = await WeightedPool.create(params);
+      poolId = await pool.getPoolId();
+    });
+
+    sharedBeforeEach('join pool (aka fund liquidity)', async () => {
+      await tokens.mint({ to: owner, amount: fp(100) });
+      await tokens.approve({ from: owner, to: await pool.getVault() });
+      await pool.init({ from: owner, initialBalances });
+    });
+
     describe('swapping', () => {
-      sharedBeforeEach('deploy pool', async () => {
-        vault = await Vault.create();
-        const params = {
-          tokens: tokens.subset(numberExistingTokens),
-          weights: originalWeights,
-          owner,
-          poolType: WeightedPoolType.INDEX_POOL,
-          fromFactory: true,
-          vault,
-        };
-        pool = await WeightedPool.create(params);
-      });
-
-      sharedBeforeEach('initialize pool', async () => {
-        await tokens.mint({ to: owner, amount: fp(100) });
-        await tokens.approve({ from: owner, to: await pool.getVault() });
-        await pool.init({ from: owner, initialBalances });
-      });
-
-      sharedBeforeEach('swap', async () => {
-        poolId = await pool.getPoolId();
+      sharedBeforeEach('assemble swap params', async () => {
         singleSwap = {
           poolId,
           kind: SwapKind.GivenIn,
-          assetIn: allTokens.first.address,
+          assetIn: allTokens.third.address,
           assetOut: allTokens.second.address,
           amount: swapAmount,
           userData: '0x',
@@ -396,15 +388,47 @@ describe('IndexPool', function () {
         funds = {
           sender: owner.address,
           fromInternalBalance: false,
-          recipient: other.address,
+          recipient: owner.address,
           toInternalBalance: false,
         };
-        await vault.instance.connect(owner).swap(singleSwap, funds, limit, deadline);
       });
 
-      it('adds tokens of type assetIn to the vault', async () => {
-        const difference = (await tokens.first.balanceOf(vault.address)).sub(initialPoolAmounts);
+      it('adds correct amount tokens of type assetIn to the vault', async () => {
+        await vault.instance.connect(owner).swap(singleSwap, funds, limit, deadline);
+
+        const difference = (await tokens.third.balanceOf(vault.address)).sub(initialPoolAmounts);
         expect(difference).to.equal(swapAmount);
+      });
+
+      it('removes correct amount tokens of type assetOut from the vault', async () => {
+        const defaultFeePercentage = 0.01;
+        const defaultFeeAmount = pct(swapAmount, defaultFeePercentage);
+        const expectedAmountOut = await pool.estimateGivenIn({
+          in: tokens.third,
+          out: tokens.second,
+          amount: swapAmount.sub(defaultFeeAmount),
+        });
+
+        await vault.instance.connect(owner).swap(singleSwap, funds, limit, deadline);
+
+        const vaultDifference = initialPoolAmounts.sub(await tokens.second.balanceOf(vault.address));
+        expect(vaultDifference).to.equalWithError(expectedAmountOut, 0.0001);
+      });
+    });
+
+    describe('exit pool (aka remove liquidity)', () => {
+      const removeAmount = fp(0.6);
+      const residualAmount = initialPoolAmounts.sub(removeAmount);
+
+      sharedBeforeEach('remove liquidity', async () => {
+        await pool.exitGivenOut({ from: owner, amountsOut: initialBalances.map(() => removeAmount) });
+      });
+
+      it('removes the tokens from the vaults balance', async () => {
+        const expectedPoolAmounts = initialBalances.map(() => residualAmount);
+        const { balances: actualPoolAmounts } = await vault.getPoolTokens(poolId);
+
+        expect(actualPoolAmounts).to.eql(expectedPoolAmounts);
       });
     });
   });

--- a/pkg/pool-weighted/test/IndexPool.test.ts
+++ b/pkg/pool-weighted/test/IndexPool.test.ts
@@ -8,7 +8,6 @@ import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 import WeightedPool from '@balancer-labs/v2-helpers/src/models/pools/weighted/WeightedPool';
 import { range } from 'lodash';
 import { WeightedPoolType } from '../../../pvt/helpers/src/models/pools/weighted/types';
-import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 
 import {
   BatchSwapStep,

--- a/pvt/helpers/src/models/tokens/TokenList.ts
+++ b/pvt/helpers/src/models/tokens/TokenList.ts
@@ -40,6 +40,10 @@ export default class TokenList {
     return this.get(1);
   }
 
+  get third(): Token {
+    return this.get(2);
+  }
+
   get WETH(): Token {
     return this.findBySymbol('WETH');
   }


### PR DESCRIPTION
Joining is currently just tested implicitly through a `sharedBeforeEach` block.

closes #43 