### PR TITLE
Chore: Prevent new (uninitialized) token from being swapped out

### DIFF
--- a/pkg/pool-weighted/contracts/smart/IndexPool.sol
+++ b/pkg/pool-weighted/contracts/smart/IndexPool.sol
@@ -316,6 +316,22 @@ contract IndexPool is BaseWeightedPool, ReentrancyGuard {
         );
     }
 
+    /// @dev Hook is called when someone swaps through vault.
+    /// @param swapRequest Swap params.
+    /// @param currentBalanceTokenIn Vault balance of token that is swapped into the pool.
+    /// @param currentBalanceTokenOut Vault balance of token that is swapped out of the pool.
+    /// @return Amount of tokens that the user will receive in return for their token.
+    function onSwap(
+        SwapRequest memory swapRequest,
+        uint256 currentBalanceTokenIn,
+        uint256 currentBalanceTokenOut
+    ) public override returns (uint256) {
+        //cannot swap out uninitialized token
+        require(minBalances[swapRequest.tokenOut] == 0, "Uninitialized token");
+
+        return super.onSwap(swapRequest, currentBalanceTokenIn, currentBalanceTokenOut);
+    }
+
     /// @dev Calculates the time horizon for a rebasing based on max weight change.
     /// @param tokens Array with addresses of tokens.
     /// @param desiredWeights Array with desired weights of tokens. Must be in same order.

--- a/pkg/pool-weighted/test/IndexPool.test.ts
+++ b/pkg/pool-weighted/test/IndexPool.test.ts
@@ -432,7 +432,7 @@ describe('IndexPool', function () {
       });
 
       context('when attempting to swap new token out of pool', () => {
-        it.only('reverts "Uninitialized token"', async () => {
+        it('reverts "Uninitialized token"', async () => {
           const singleSwap = {
             poolId,
             kind: SwapKind.GivenIn,

--- a/pkg/pool-weighted/test/IndexPool.test.ts
+++ b/pkg/pool-weighted/test/IndexPool.test.ts
@@ -430,6 +430,31 @@ describe('IndexPool', function () {
 
         expect(newTokenTargetWeights).to.equalWithError(expectedNewTokenTargetWeights, 0.0001);
       });
+
+      context('when attempting to swap new token out of pool', () => {
+        it.only('reverts "Uninitialized token"', async () => {
+          const singleSwap = {
+            poolId,
+            kind: SwapKind.GivenIn,
+            assetIn: reindexTokens[0],
+            assetOut: reindexTokens[3],
+            amount: fp(0.001),
+            userData: '0x',
+          };
+          const funds = {
+            sender: owner.address,
+            fromInternalBalance: false,
+            recipient: other.address,
+            toInternalBalance: false,
+          };
+          const limit = 0; // Minimum amount out
+          const deadline = MAX_UINT256;
+
+          await expect(vault.instance.connect(owner).swap(singleSwap, funds, limit, deadline)).to.be.revertedWith(
+            'Uninitialized token'
+          );
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
Should be reviewed and merged after #50 since it is branched from that PR.

closes #44 