### PR TITLE
Chore: Reduce contract size

### DIFF
--- a/pkg/balancer-js/src/utils/errors.ts
+++ b/pkg/balancer-js/src/utils/errors.ts
@@ -128,6 +128,8 @@ const balancerErrorCodes: Record<string, string> = {
   '600': 'SWAP_FEE_PERCENTAGE_TOO_HIGH',
   '601': 'FLASH_LOAN_FEE_PERCENTAGE_TOO_HIGH',
   '602': 'INSUFFICIENT_FLASH_LOAN_FEE_AMOUNT',
+  '700': 'INVALID_ZERO_MINIMUM_BALANCE',
+  '701': 'UNINITIALIZED_TOKEN',
 };
 
 export class BalancerErrors {

--- a/pkg/pool-weighted/contracts/smart/IIndexPool.sol
+++ b/pkg/pool-weighted/contracts/smart/IIndexPool.sol
@@ -19,5 +19,11 @@ interface IIndexPool {
         address controller;
     }
 
-    event WeightChange(IERC20[] tokens, uint256[] startWeights, uint256[] endWeights, uint256 endTime);
+    event WeightChange(
+        IERC20[] tokens,
+        uint256[] startWeights,
+        uint256[] endWeights,
+        uint256 startTime,
+        uint256 endTime
+    );
 }

--- a/pkg/pool-weighted/contracts/smart/IIndexPool.sol
+++ b/pkg/pool-weighted/contracts/smart/IIndexPool.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/IERC20.sol";
+import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
+
+interface IIndexPool {
+    struct NewPoolParams {
+        IVault vault;
+        string name;
+        string symbol;
+        IERC20[] tokens;
+        uint256[] normalizedWeights;
+        uint256 swapFeePercentage;
+        uint256 pauseWindowDuration;
+        uint256 bufferPeriodDuration;
+        address controller;
+    }
+
+    event WeightChange(IERC20[] tokens, uint256[] startWeights, uint256[] endWeights, uint256 endTime);
+}

--- a/pkg/pool-weighted/contracts/smart/IIndexPool.sol
+++ b/pkg/pool-weighted/contracts/smart/IIndexPool.sol
@@ -24,6 +24,7 @@ interface IIndexPool {
         uint256[] startWeights,
         uint256[] endWeights,
         uint256 startTime,
-        uint256 endTime
+        uint256 endTime,
+        uint256[] finalTargetWeights
     );
 }

--- a/pkg/pool-weighted/contracts/smart/IndexPool.sol
+++ b/pkg/pool-weighted/contracts/smart/IndexPool.sol
@@ -183,7 +183,7 @@ contract IndexPool is BaseWeightedPool, ReentrancyGuard {
         IERC20[] memory tokens,
         uint256[] memory newTokenTargetWeights
     ) internal virtual {
-        uint256 normalizedSum = 0;
+        uint256 normalizedSum;
         bytes32 tokenState;
         for (uint256 i = 0; i < endWeights.length; i++) {
             uint256 endWeight = endWeights[i];
@@ -217,7 +217,6 @@ contract IndexPool is BaseWeightedPool, ReentrancyGuard {
     }
 
     function reweighTokens(IERC20[] calldata tokens, uint256[] calldata desiredWeights) public authenticate {
-        require(block.timestamp >= _getMiscData().decodeUint32(_END_TIME_OFFSET), "Weight change already in process");
         InputHelpers.ensureInputLengthMatch(tokens.length, desiredWeights.length);
         _startGradualWeightChange(
             block.timestamp,
@@ -228,14 +227,6 @@ contract IndexPool is BaseWeightedPool, ReentrancyGuard {
             new uint256[](tokens.length)
         );
     }
-
-    // function reweighTokens(IERC20[] calldata tokens, uint256[] calldata desiredWeights) public authenticate {
-    //     uint256 endTime = _getMiscData().decodeUint32(_END_TIME_OFFSET);
-    //     require(block.timestamp >= endTime, "Weight change is already in process");
-    //     InputHelpers.ensureInputLengthMatch(tokens.length, desiredWeights.length);
-    //     uint256 changeTime = _calcReweighTime(tokens, desiredWeights);
-    //     _updateWeightsGradually(block.timestamp, block.timestamp.add(changeTime), desiredWeights);
-    // }
 
     function reindexTokens(
         IERC20[] memory tokens,

--- a/pkg/pool-weighted/contracts/smart/IndexPool.sol
+++ b/pkg/pool-weighted/contracts/smart/IndexPool.sol
@@ -167,7 +167,7 @@ contract IndexPool is BaseWeightedPool, ReentrancyGuard, IIndexPool {
             _getMiscData().insertUint32(startTime, _START_TIME_OFFSET).insertUint32(endTime, _END_TIME_OFFSET)
         );
 
-        emit WeightChange(tokens, startWeights, endWeights, startTime, endTime);
+        emit WeightChange(tokens, startWeights, endWeights, startTime, endTime, newTokenTargetWeights);
     }
 
     function reweighTokens(IERC20[] calldata tokens, uint256[] calldata desiredWeights) public authenticate {

--- a/pkg/pool-weighted/contracts/smart/IndexPool.sol
+++ b/pkg/pool-weighted/contracts/smart/IndexPool.sol
@@ -218,7 +218,7 @@ contract IndexPool is BaseWeightedPool, ReentrancyGuard {
 
     function reweighTokens(IERC20[] calldata tokens, uint256[] calldata desiredWeights) public authenticate {
         uint256 endTime = _getMiscData().decodeUint32(_END_TIME_OFFSET);
-        require(block.timestamp >= endTime, "Weight change is already in process");
+        require(block.timestamp >= endTime, "Weight change already in process");
         InputHelpers.ensureInputLengthMatch(tokens.length, desiredWeights.length);
         uint256 changeTime = _calcReweighTime(tokens, desiredWeights);
         _startGradualWeightChange(

--- a/pkg/pool-weighted/contracts/smart/IndexPool.sol
+++ b/pkg/pool-weighted/contracts/smart/IndexPool.sol
@@ -207,7 +207,7 @@ contract IndexPool is BaseWeightedPool, ReentrancyGuard, IIndexPool {
         uint8 newTokenCounter;
 
         for (uint8 i = 0; i < tokens.length; i++) {
-            require(minimumBalances[i] != 0, "Invalid zero minimum balance");
+            _require(minimumBalances[i] != 0, Errors.INVALID_ZERO_MINIMUM_BALANCE);
             bytes32 currentTokenState = _tokenState[IERC20(tokens[i])];
 
             // check if token is new token by checking if no startTime is set
@@ -258,7 +258,7 @@ contract IndexPool is BaseWeightedPool, ReentrancyGuard, IIndexPool {
         uint256 currentBalanceTokenOut
     ) public override returns (uint256) {
         //cannot swap out uninitialized token
-        require(minBalances[swapRequest.tokenOut] == 0, "Uninitialized token");
+        _require(minBalances[swapRequest.tokenOut] == 0, Errors.UNINITIALIZED_TOKEN);
 
         // check if uninitialized token will be swapped INTO the pool
         if (minBalances[swapRequest.tokenIn] != 0) {

--- a/pkg/pool-weighted/contracts/smart/IndexPool.sol
+++ b/pkg/pool-weighted/contracts/smart/IndexPool.sol
@@ -182,6 +182,10 @@ contract IndexPool is BaseWeightedPool, ReentrancyGuard, IIndexPool {
         );
     }
 
+    /// @dev Identifies new tokens, registers them with pool and initiates weight change.
+    /// @param tokens List of pool tokens.
+    /// @param desiredWeights List of desired weights for tokens.
+    /// @param minimumBalances List of minimum balances per token which would represent 1% of pool value.
     function reindexTokens(
         IERC20[] memory tokens,
         uint256[] memory desiredWeights,

--- a/pkg/pool-weighted/contracts/smart/IndexPool.sol
+++ b/pkg/pool-weighted/contracts/smart/IndexPool.sol
@@ -440,7 +440,7 @@ contract IndexPool is BaseWeightedPool, ReentrancyGuard, IIndexPool {
     function _isOwnerOnlyAction(bytes32 actionId) internal view virtual override returns (bool) {
         return
             (actionId == getActionId(this.reindexTokens.selector)) ||
-            // (actionId == getActionId(this.reweighTokens.selector)) ||
+            (actionId == getActionId(this.reweighTokens.selector)) ||
             super._isOwnerOnlyAction(actionId);
     }
 }

--- a/pkg/pool-weighted/contracts/smart/IndexPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/smart/IndexPoolFactory.sol
@@ -16,6 +16,7 @@ pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
+import "./IIndexPool.sol";
 
 import "@balancer-labs/v2-pool-utils/contracts/factories/BasePoolSplitCodeFactory.sol";
 import "@balancer-labs/v2-pool-utils/contracts/factories/FactoryWidePauseWindow.sol";
@@ -42,7 +43,7 @@ contract IndexPoolFactory is BasePoolSplitCodeFactory, FactoryWidePauseWindow {
         return
             _create(
                 abi.encode(
-                    IndexPool.NewPoolParams({
+                    IIndexPool.NewPoolParams({
                         vault: getVault(),
                         name: name,
                         symbol: symbol,

--- a/pkg/pool-weighted/contracts/utils/IndexPoolUtils.sol
+++ b/pkg/pool-weighted/contracts/utils/IndexPoolUtils.sol
@@ -259,6 +259,7 @@ library IndexPoolUtils {
 
     function getOriginalReindexTargets(IERC20[] memory tokens, mapping(IERC20 => bytes32) storage tokenState)
         internal
+        view
         returns (uint256[] memory originalReindexTargets)
     {
         uint256 numTokens = tokens.length;

--- a/pkg/pool-weighted/contracts/utils/IndexPoolUtils.sol
+++ b/pkg/pool-weighted/contracts/utils/IndexPoolUtils.sol
@@ -126,6 +126,16 @@ library IndexPoolUtils {
         return FixedPoint.mulUp(_UNINITIALIZED_WEIGHT, incentivizationFactor);
     }
 
+    /// @dev Assembles params to be used for reindex call.
+    /// @param tokens List of pool tokens.
+    /// @param desiredWeights List of desired weights for tokens.
+    /// @param minimumBalances List of minimum balances per token which would represent 1% of pool value.
+    /// @param tokenState The mapping of token states.
+    /// @param minBalances The mapping of minimum balances for uninitialzed tokens.
+    /// @return fixedWeights Weights that are fixed and that the other non-fixed weights need to be adjusted for.
+    /// @return newTokenTargetWeights contains only the final target weights for uninitialized tokens (else zero).
+    /// @return existingTokens contains only the existing pool token addresses (else zero).
+    /// @return newTokens contains only the new pool token addresses (no zeros!).
     function assembleReindexParams(
         IERC20[] memory tokens,
         uint256[] memory desiredWeights,
@@ -207,6 +217,16 @@ library IndexPoolUtils {
             );
     }
 
+    /// @dev Assembles params to be used for the next weight change when a token becomes initialized.
+    /// @param tokens List of pool tokens.
+    /// @param tokenIn Address of uninitialized token that is swapped in.
+    /// @param currentBalanceTokenIn Balance of uninitialized token that is swapped in.
+    /// @param amountIn Amount of uninitialized token that is swapped in.
+    /// @param tokenState The mapping of token states.
+    /// @param minBalanceTokenIn Minimum balance of uninitialized token that is swapped in.
+    /// @return nextEndWeights End weights to be used for new weight change.
+    /// @return fixedStartWeights Used to calculate the start weights for the new weight change.
+    /// @return newTokenTargetWeights Used to remember the final target weigths of any uninitialized tokens.
     function assembleInitializationParams(
         IERC20[] memory tokens,
         IERC20 tokenIn,
@@ -256,6 +276,10 @@ library IndexPoolUtils {
         nextEndWeights = normalizeInterpolated(getOriginalReindexTargets(tokens, tokenState), fixedEndWeights);
     }
 
+    /// @dev Interpolates back to the initial reindex target weights (no need to store - gas saving!)
+    /// @param tokens List of pool tokens.
+    /// @param tokenState The mapping of token states.
+    /// @return originalReindexTargets Initial reindex target weights.
     function getOriginalReindexTargets(IERC20[] memory tokens, mapping(IERC20 => bytes32) storage tokenState)
         internal
         view

--- a/pkg/pool-weighted/contracts/utils/IndexPoolUtils.sol
+++ b/pkg/pool-weighted/contracts/utils/IndexPoolUtils.sol
@@ -7,8 +7,6 @@ import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/IERC20.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/WordCodec.sol";
 import "../smart/WeightCompression.sol";
 
-import "hardhat/console.sol";
-
 library IndexPoolUtils {
     using FixedPoint for uint256;
     using Math for uint256;
@@ -218,6 +216,7 @@ library IndexPoolUtils {
         uint256 minBalanceTokenIn
     )
         external
+        view
         returns (
             uint256[] memory nextEndWeights,
             uint256[] memory fixedStartWeights,

--- a/pkg/pool-weighted/contracts/utils/IndexPoolUtils.sol
+++ b/pkg/pool-weighted/contracts/utils/IndexPoolUtils.sol
@@ -17,7 +17,7 @@ library IndexPoolUtils {
     /// @param _fixedWeights Array with weights of tokens. Those that are non-zero are fixed.
     /// @return Array with scaled and fixed weights of tokens. Should add up to one.
     function normalizeInterpolated(uint256[] memory _baseWeights, uint256[] memory _fixedWeights)
-        internal
+        external
         pure
         returns (uint256[] memory)
     {
@@ -89,7 +89,7 @@ library IndexPoolUtils {
     /// @param _minimumBalance Minimum balance set for the uninitialized token (= initialization threshold)
     /// @return Weight to be used to calculate the price of an uninitalized token.
     function getUninitializedTokenWeight(uint256 _tokenBalanceBeforeSwap, uint256 _minimumBalance)
-        internal
+        external
         pure
         returns (uint256)
     {

--- a/pkg/pool-weighted/hardhat.config.ts
+++ b/pkg/pool-weighted/hardhat.config.ts
@@ -1,5 +1,6 @@
 import '@nomiclabs/hardhat-ethers';
 import '@nomiclabs/hardhat-waffle';
+import 'hardhat-contract-sizer';
 
 import { hardhatBaseConfig } from '@balancer-labs/v2-common';
 import { name } from './package.json';
@@ -14,5 +15,11 @@ export default {
   solidity: {
     compilers: hardhatBaseConfig.compilers,
     overrides: { ...hardhatBaseConfig.overrides(name) },
+  },
+  contractSizer: {
+    alphaSort: true,
+    disambiguatePaths: false,
+    runOnCompile: true,
+    strict: true,
   },
 };

--- a/pkg/pool-weighted/package.json
+++ b/pkg/pool-weighted/package.json
@@ -52,6 +52,7 @@
     "ethereum-waffle": "^3.0.2",
     "ethers": "^5.4.1",
     "hardhat": "^2.4.1",
+    "hardhat-contract-sizer": "^2.1.1",
     "lodash.frompairs": "^4.0.1",
     "lodash.pick": "^4.4.0",
     "lodash.range": "^3.2.0",

--- a/pkg/pool-weighted/test/IndexPool.test.ts
+++ b/pkg/pool-weighted/test/IndexPool.test.ts
@@ -29,7 +29,7 @@ const getTimeForWeightChange = (weightDifference: number) => {
   return (weightDifference / 1e18) * 86400 * 100;
 };
 
-describe('IndexPool', function () {
+describe.only('IndexPool', function () {
   let owner: SignerWithAddress,
     controller: SignerWithAddress,
     other: SignerWithAddress,

--- a/pkg/pool-weighted/test/IndexPool.test.ts
+++ b/pkg/pool-weighted/test/IndexPool.test.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'hardhat';
 import { expect } from 'chai';
-import { BigNumber } from 'ethers';
+// import { BigNumber } from 'ethers';
 import { range } from 'lodash';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 import { fp, pct, fromFp } from '@balancer-labs/v2-helpers/src/numbers';
@@ -13,22 +13,22 @@ import * as expectEvent from '../../../pvt/helpers/src/test/expectEvent';
 import { calcOutGivenIn } from '@balancer-labs/v2-helpers/src/models/pools/weighted/math';
 import { WeightedPoolType } from '../../../pvt/helpers/src/models/pools/weighted/types';
 
-const calculateMaxWeightDifference = (oldWeights: BigNumber[], newWeights: BigNumber[]) => {
-  let maxWeightDifference = 0;
-  for (let i = 0; i < newWeights.length; i++) {
-    if (Math.abs(Number(newWeights[i]) - Number(oldWeights[i])) > maxWeightDifference) {
-      maxWeightDifference = Math.abs(Number(newWeights[i]) - Number(oldWeights[i]));
-    }
-  }
-  return maxWeightDifference;
-};
+// const calculateMaxWeightDifference = (oldWeights: BigNumber[], newWeights: BigNumber[]) => {
+//   let maxWeightDifference = 0;
+//   for (let i = 0; i < newWeights.length; i++) {
+//     if (Math.abs(Number(newWeights[i]) - Number(oldWeights[i])) > maxWeightDifference) {
+//       maxWeightDifference = Math.abs(Number(newWeights[i]) - Number(oldWeights[i]));
+//     }
+//   }
+//   return maxWeightDifference;
+// };
 
-const getTimeForWeightChange = (weightDifference: number) => {
-  // 1e18 is 100%, we need to calculate on how much percent the weight changes first,
-  // then we can understand how much time do we need by multiplying amount of percents o amount of seconds per day
-  // (1% change in a day at max rate)
-  return (weightDifference / 1e18) * 86400 * 100;
-};
+// const getTimeForWeightChange = (weightDifference: number) => {
+//   // 1e18 is 100%, we need to calculate on how much percent the weight changes first,
+//   // then we can understand how much time do we need by multiplying amount of percents o amount of seconds per day
+//   // (1% change in a day at max rate)
+//   return (weightDifference / 1e18) * 86400 * 100;
+// };
 
 describe.only('IndexPool', function () {
   let owner: SignerWithAddress,

--- a/pkg/pool-weighted/test/IndexPool.test.ts
+++ b/pkg/pool-weighted/test/IndexPool.test.ts
@@ -246,63 +246,56 @@ describe.only('IndexPool', function () {
     });
   });
 
-  // describe('#reweighTokens', () => {
-  //   sharedBeforeEach('deploy pool', async () => {
-  //     const params = {
-  //       tokens,
-  //       weights,
-  //       owner,
-  //       poolType: WeightedPoolType.INDEX_POOL,
-  //       swapEnabledOnStart: false,
-  //     };
-  //     pool = await WeightedPool.create(params);
-  //   });
+  describe.only('#reweighTokens', () => {
+    sharedBeforeEach('deploy pool', async () => {
+      const params = {
+        tokens,
+        weights,
+        owner,
+        poolType: WeightedPoolType.INDEX_POOL,
+        swapEnabledOnStart: false,
+      };
+      pool = await WeightedPool.create(params);
+    });
 
-  //   context('when input array lengths differ', () => {
-  //     it('reverts: "INPUT_LENGTH_MISMATCH"', async () => {
-  //       const threeAddresses = allTokens.subset(3).tokens.map((token) => token.address);
-  //       const twoWeights = [fp(0.5), fp(0.5)];
-
-  //       await expect(pool.reweighTokens(threeAddresses, twoWeights)).to.be.revertedWith('INPUT_LENGTH_MISMATCH');
-  //     });
-  //   });
-
-  //   context('when weights are not normalized', () => {
-  //     it('reverts: "INPUT_LENGTH_MISMATCH"', async () => {
-  //       const addresses = allTokens.subset(2).tokens.map((token) => token.address);
-  //       const denormalizedWeights = [fp(0.5), fp(0.3)];
-
-  //       await expect(pool.reweighTokens(addresses, denormalizedWeights)).to.be.revertedWith(
-  //         'NORMALIZED_WEIGHT_INVARIANT'
-  //       );
-  //     });
-  //   });
-
-  //   context('with valid inputs', () => {
-  //     const desiredWeights = [fp(0.1), fp(0.3), fp(0.5), fp(0.1)];
-
-  //     sharedBeforeEach('deploy pool', async () => {
-  //       await pool.reweighTokens(
-  //         allTokens.subset(4).tokens.map((token) => token.address),
-  //         desiredWeights
-  //       );
-  //     });
-
-  //     it('sets the correct endWeights', async () => {
-  //       const { endWeights } = await pool.getGradualWeightUpdateParams();
-
-  //       expect(endWeights).to.equalWithError(desiredWeights, 0.0001);
-  //     });
-
-  //     it('sets the correct rebalancing period', async () => {
-  //       const maxWeightDifference = calculateMaxWeightDifference(desiredWeights, weights);
-  //       const time = getTimeForWeightChange(maxWeightDifference);
-  //       const { startTime, endTime } = await pool.getGradualWeightUpdateParams();
-
-  //       expect(Number(endTime) - Number(startTime)).to.equalWithError(time, 0.0001);
-  //     });
-  //   });
-  // });
+    context('when input array lengths differ', () => {
+      it('reverts: "INPUT_LENGTH_MISMATCH"', async () => {
+        const threeAddresses = allTokens.subset(3).tokens.map((token) => token.address);
+        const twoWeights = [fp(0.5), fp(0.5)];
+        await expect(pool.reweighTokens(controller, threeAddresses, twoWeights)).to.be.revertedWith(
+          'INPUT_LENGTH_MISMATCH'
+        );
+      });
+    });
+    context('when weights are not normalized', () => {
+      it('reverts: "INPUT_LENGTH_MISMATCH"', async () => {
+        const addresses = allTokens.subset(2).tokens.map((token) => token.address);
+        const denormalizedWeights = [fp(0.5), fp(0.3)];
+        await expect(pool.reweighTokens(controller, addresses, denormalizedWeights)).to.be.revertedWith(
+          'NORMALIZED_WEIGHT_INVARIANT'
+        );
+      });
+    });
+    //   context('with valid inputs', () => {
+    //     const desiredWeights = [fp(0.1), fp(0.3), fp(0.5), fp(0.1)];
+    //     sharedBeforeEach('deploy pool', async () => {
+    //       await pool.reweighTokens(
+    //         allTokens.subset(4).tokens.map((token) => token.address),
+    //         desiredWeights
+    //       );
+    //     });
+    //     it('sets the correct endWeights', async () => {
+    //       const { endWeights } = await pool.getGradualWeightUpdateParams();
+    //       expect(endWeights).to.equalWithError(desiredWeights, 0.0001);
+    //     });
+    //     it('sets the correct rebalancing period', async () => {
+    //       const maxWeightDifference = calculateMaxWeightDifference(desiredWeights, weights);
+    //       const time = getTimeForWeightChange(maxWeightDifference);
+    //       const { startTime, endTime } = await pool.getGradualWeightUpdateParams();
+    //       expect(Number(endTime) - Number(startTime)).to.equalWithError(time, 0.0001);
+    //     });
+    //   });
+  });
 
   describe('#reindexTokens', () => {
     describe('input validation', () => {

--- a/pkg/pool-weighted/test/IndexPool.test.ts
+++ b/pkg/pool-weighted/test/IndexPool.test.ts
@@ -364,13 +364,13 @@ describe.only('IndexPool', function () {
       });
 
       context('when a minimum balance is zero', () => {
-        it('reverts: "INVALID_ZERO_MINIMUM_BALANCE"', async () => {
+        it('reverts: "BAL#700 (INVALID_ZERO_MINIMUM_BALANCE)"', async () => {
           const addresses = allTokens.subset(2).tokens.map((token) => token.address);
           const weights = [fp(0.5), fp(0.5)];
           const invalidMinimumBalances = [1000, 0];
 
           await expect(pool.reindexTokens(controller, addresses, weights, invalidMinimumBalances)).to.be.revertedWith(
-            'Invalid zero minimum balance'
+            'INVALID_ZERO_MINIMUM_BALANCE'
           );
         });
       });
@@ -465,7 +465,7 @@ describe.only('IndexPool', function () {
       });
 
       context('when attempting to swap new token out of pool', () => {
-        it('reverts "Uninitialized token"', async () => {
+        it('reverts "UNINITIALIZED_TOKEN"', async () => {
           await pool.reindexTokens(controller, reindexTokens, reindexWeights, minimumBalances);
 
           const singleSwap = {
@@ -486,7 +486,7 @@ describe.only('IndexPool', function () {
           const deadline = MAX_UINT256;
 
           await expect(vault.instance.connect(owner).swap(singleSwap, funds, limit, deadline)).to.be.revertedWith(
-            'Uninitialized token'
+            'UNINITIALIZED_TOKEN'
           );
         });
       });

--- a/pkg/pool-weighted/test/IndexPool.test.ts
+++ b/pkg/pool-weighted/test/IndexPool.test.ts
@@ -276,25 +276,34 @@ describe.only('IndexPool', function () {
         );
       });
     });
-    //   context('with valid inputs', () => {
-    //     const desiredWeights = [fp(0.1), fp(0.3), fp(0.5), fp(0.1)];
-    //     sharedBeforeEach('deploy pool', async () => {
-    //       await pool.reweighTokens(
-    //         allTokens.subset(4).tokens.map((token) => token.address),
-    //         desiredWeights
-    //       );
-    //     });
-    //     it('sets the correct endWeights', async () => {
-    //       const { endWeights } = await pool.getGradualWeightUpdateParams();
-    //       expect(endWeights).to.equalWithError(desiredWeights, 0.0001);
-    //     });
-    //     it('sets the correct rebalancing period', async () => {
-    //       const maxWeightDifference = calculateMaxWeightDifference(desiredWeights, weights);
-    //       const time = getTimeForWeightChange(maxWeightDifference);
-    //       const { startTime, endTime } = await pool.getGradualWeightUpdateParams();
-    //       expect(Number(endTime) - Number(startTime)).to.equalWithError(time, 0.0001);
-    //     });
-    //   });
+
+    context('with valid inputs', () => {
+      const desiredWeights = [fp(0.1), fp(0.3), fp(0.5), fp(0.1)];
+
+      it('emits an event that contains the weight state change params', async () => {
+        const tx = await pool.reweighTokens(
+          controller,
+          allTokens.subset(4).tokens.map((token) => token.address),
+          desiredWeights
+        );
+
+        const receipt = await tx.wait();
+
+        expectEvent.inReceiptWithError(receipt, 'WeightChange', {
+          tokens: allTokens.subset(4).tokens.map((token) => token.address),
+          startWeights: weights,
+          endWeights: desiredWeights,
+          finalTargetWeights: [fp(0), fp(0), fp(0), fp(0)],
+        });
+      });
+
+      // it('sets the correct rebalancing period', async () => {
+      //   const maxWeightDifference = calculateMaxWeightDifference(desiredWeights, weights);
+      //   const time = getTimeForWeightChange(maxWeightDifference);
+      //   const { startTime, endTime } = await pool.getGradualWeightUpdateParams();
+      //   expect(Number(endTime) - Number(startTime)).to.equalWithError(time, 0.0001);
+      // });
+    });
   });
 
   describe('#reindexTokens', () => {

--- a/pkg/pool-weighted/test/IndexPool.test.ts
+++ b/pkg/pool-weighted/test/IndexPool.test.ts
@@ -535,7 +535,7 @@ describe.only('IndexPool', function () {
         });
       });
 
-      context.only('when the new token becomes initialized', () => {
+      context('when the new token becomes initialized', () => {
         const numberOfSwapsUntilInitialization = 4;
         const weightAdjustmentFactor =
           (4 * fromFp(swapInAmount).toNumber()) / fromFp(defaultUninitializedWeight).toNumber();

--- a/pkg/pool-weighted/test/IndexPool.test.ts
+++ b/pkg/pool-weighted/test/IndexPool.test.ts
@@ -577,7 +577,7 @@ describe.only('IndexPool', function () {
           expect(minimumBalance).to.equal(0);
         });
 
-        it('emits an event that contains the correct state change params', async () => {
+        it.only('emits an event that contains the correct state change params', async () => {
           const expectedNewTokenTargetWeights = new Array(numberExistingTokens + numberNewTokens).fill(fp(0));
 
           const singleSwap = {
@@ -601,14 +601,14 @@ describe.only('IndexPool', function () {
           for (let i = 0; i < numberOfSwapsUntilInitialization - 1; i++) {
             await vault.instance.connect(owner).swap(singleSwap, funds, limit, deadline);
           }
-
+          console.log(pool.instance.i);
           const tx = await pool.reindexTokens(controller, reindexTokens, reindexWeights, minimumBalances);
 
           const receipt = await tx.wait();
 
-          expectEvent.inReceiptWithError(receipt, 'WeightChange', {
+          expectEvent.inIndirectReceiptWithError(receipt, pool.instance.interface, 'WeightChange', {
             tokens: reindexTokens,
-            startWeights: expectedNewStartWeights,
+            startWeights: expectedNewStartWeightsAfterInit,
             endWeights: expectedIntermediateEndWeights,
             finalTargetWeights: expectedNewTokenTargetWeights,
           });

--- a/pkg/pool-weighted/test/IndexPool.test.ts
+++ b/pkg/pool-weighted/test/IndexPool.test.ts
@@ -9,8 +9,9 @@ import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 import WeightedPool from '@balancer-labs/v2-helpers/src/models/pools/weighted/WeightedPool';
 import { MAX_UINT256 } from '@balancer-labs/v2-helpers/src/constants';
 import { FundManagement, SingleSwap, SwapKind } from '@balancer-labs/balancer-js';
-import { WeightedPoolType } from '../../../pvt/helpers/src/models/pools/weighted/types';
+import * as expectEvent from '../../../pvt/helpers/src/test/expectEvent';
 import { calcOutGivenIn } from '@balancer-labs/v2-helpers/src/models/pools/weighted/math';
+import { WeightedPoolType } from '../../../pvt/helpers/src/models/pools/weighted/types';
 
 const calculateMaxWeightDifference = (oldWeights: BigNumber[], newWeights: BigNumber[]) => {
   let maxWeightDifference = 0;

--- a/pkg/pool-weighted/test/IndexPool.test.ts
+++ b/pkg/pool-weighted/test/IndexPool.test.ts
@@ -246,7 +246,7 @@ describe.only('IndexPool', function () {
     });
   });
 
-  describe.only('#reweighTokens', () => {
+  describe('#reweighTokens', () => {
     sharedBeforeEach('deploy pool', async () => {
       const params = {
         tokens,
@@ -535,7 +535,7 @@ describe.only('IndexPool', function () {
         });
       });
 
-      context('when the new token becomes initialized', () => {
+      context.only('when the new token becomes initialized', () => {
         const numberOfSwapsUntilInitialization = 4;
         const weightAdjustmentFactor =
           (4 * fromFp(swapInAmount).toNumber()) / fromFp(defaultUninitializedWeight).toNumber();

--- a/pkg/pool-weighted/test/IndexPool.test.ts
+++ b/pkg/pool-weighted/test/IndexPool.test.ts
@@ -30,7 +30,7 @@ import { WeightedPoolType } from '../../../pvt/helpers/src/models/pools/weighted
 //   return (weightDifference / 1e18) * 86400 * 100;
 // };
 
-describe.only('IndexPool', function () {
+describe('IndexPool', function () {
   let owner: SignerWithAddress,
     controller: SignerWithAddress,
     other: SignerWithAddress,

--- a/pkg/pool-weighted/test/IndexPool.test.ts
+++ b/pkg/pool-weighted/test/IndexPool.test.ts
@@ -533,7 +533,7 @@ describe.only('IndexPool', function () {
         });
       });
 
-      context('when the new token becomes initialized', () => {
+      context.only('when the new token becomes initialized', () => {
         const numberOfSwapsUntilInitialization = 4;
         const weightAdjustmentFactor =
           (4 * fromFp(swapInAmount).toNumber()) / fromFp(defaultUninitializedWeight).toNumber();
@@ -597,19 +597,19 @@ describe.only('IndexPool', function () {
           const limit = 0; // Minimum amount out
           const deadline = MAX_UINT256;
 
-          // do four swaps => will push new token balance over minimum balance
+          // do three swaps => will push new token balance over minimum balance
           for (let i = 0; i < numberOfSwapsUntilInitialization - 1; i++) {
             await vault.instance.connect(owner).swap(singleSwap, funds, limit, deadline);
           }
-          console.log(pool.instance.i);
-          const tx = await pool.reindexTokens(controller, reindexTokens, reindexWeights, minimumBalances);
+
+          const tx = await vault.instance.connect(owner).swap(singleSwap, funds, limit, deadline);
 
           const receipt = await tx.wait();
 
           expectEvent.inIndirectReceiptWithError(receipt, pool.instance.interface, 'WeightChange', {
             tokens: reindexTokens,
             startWeights: expectedNewStartWeightsAfterInit,
-            endWeights: expectedIntermediateEndWeights,
+            endWeights: reindexWeights,
             finalTargetWeights: expectedNewTokenTargetWeights,
           });
         });

--- a/pkg/solidity-utils/contracts/helpers/BalancerErrors.sol
+++ b/pkg/solidity-utils/contracts/helpers/BalancerErrors.sol
@@ -223,4 +223,8 @@ library Errors {
     uint256 internal constant SWAP_FEE_PERCENTAGE_TOO_HIGH = 600;
     uint256 internal constant FLASH_LOAN_FEE_PERCENTAGE_TOO_HIGH = 601;
     uint256 internal constant INSUFFICIENT_FLASH_LOAN_FEE_AMOUNT = 602;
+
+    // Index
+    uint256 internal constant INVALID_ZERO_MINIMUM_BALANCE = 700;
+    uint256 internal constant UNINITIALIZED_TOKEN = 701;
 }

--- a/pvt/common/setupTests.ts
+++ b/pvt/common/setupTests.ts
@@ -5,7 +5,7 @@ import chai, { expect } from 'chai';
 import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 import { BigNumberish, bn } from '@balancer-labs/v2-helpers/src/numbers';
 
-import { BalancerErrors } from '@balancer-labs/balancer-js';
+import { BalancerErrors } from '../../pkg/balancer-js/src/utils/errors';
 import { NAry } from '@balancer-labs/v2-helpers/src/models/types/types';
 import { expectEqualWithError, expectLessThanOrEqualWithError } from '@balancer-labs/v2-helpers/src/test/relativeError';
 

--- a/pvt/helpers/src/models/pools/weighted/WeightedPoolDeployer.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPoolDeployer.ts
@@ -140,6 +140,7 @@ export default {
             },
           ],
           from,
+          libraries: { IndexPoolUtils: await (await deploy('IndexPoolUtils')).address },
         });
         break;
       }
@@ -244,6 +245,7 @@ export default {
         const factory = await deploy('v2-pool-weighted/IndexPoolFactory', {
           args: [vault.address],
           from,
+          libraries: { IndexPoolUtils: await (await deploy('IndexPoolUtils')).address },
         });
         const tx = await factory.create(
           NAME,

--- a/pvt/helpers/src/test/expectEvent.ts
+++ b/pvt/helpers/src/test/expectEvent.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { BigNumber, ContractReceipt } from 'ethers';
 import { Interface, LogDescription } from 'ethers/lib/utils';
+import { expectEqualWithError } from './relativeError';
 
 // Ported from @openzeppelin/test-helpers to use with Ethers. The Test Helpers don't
 // yet have Typescript typings, so we're being lax about them here.
@@ -25,6 +26,40 @@ export function inReceipt(receipt: ContractReceipt, eventName: string, eventArgs
         }
 
         contains(e.args, k, v);
+      } catch (error) {
+        exceptions.push(error);
+        return false;
+      }
+    }
+    return true;
+  });
+
+  if (event === undefined) {
+    // Each event entry may have failed to match for different reasons,
+    // throw the first one
+    throw exceptions[0];
+  }
+
+  return event;
+}
+
+export function inReceiptWithError(receipt: ContractReceipt, eventName: string, eventArgs = {}): any {
+  if (receipt.events == undefined) {
+    throw new Error('No events found in receipt');
+  }
+
+  const events = receipt.events.filter((e) => e.event === eventName);
+  expect(events.length > 0).to.equal(true, `No '${eventName}' events found`);
+
+  const exceptions: Array<string> = [];
+  const event = events.find(function (e) {
+    for (const [k, v] of Object.entries(eventArgs)) {
+      try {
+        if (e.args == undefined) {
+          throw new Error('Event has no arguments');
+        }
+
+        containsWithError(e.args, k, v);
       } catch (error) {
         exceptions.push(error);
         return false;
@@ -109,5 +144,30 @@ function contains(args: { [key: string]: any | undefined }, key: string, value: 
       value,
       `expected event argument '${key}' to have value ${value} but got ${args[key]}`
     );
+  }
+}
+
+function containsWithError(args: { [key: string]: any | undefined }, key: string, value: any) {
+  expect(key in args).to.equal(true, `Event argument '${key}' not found`);
+
+  if (value === null) {
+    expect(args[key]).to.equal(null, `expected event argument '${key}' to be null but got ${args[key]}`);
+  } else if (BigNumber.isBigNumber(args[key]) || BigNumber.isBigNumber(value)) {
+    const actual = BigNumber.isBigNumber(args[key]) ? args[key].toString() : args[key];
+    const expected = BigNumber.isBigNumber(value) ? value.toString() : value;
+
+    expect(args[key]).to.equalWithError(
+      value,
+      `expected event argument '${key}' to have value ${expected} but got ${actual}`
+    );
+  } else {
+    if (BigNumber.isBigNumber(args[key][0])) {
+      expect(args[key]).to.equalWithError(value, 0.0001);
+    } else {
+      expect(args[key]).to.be.deep.equal(
+        value,
+        `expected event argument '${key}' to have value ${value} but got ${args[key]}`
+      );
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -452,6 +452,7 @@ __metadata:
     ethereum-waffle: ^3.0.2
     ethers: ^5.4.1
     hardhat: ^2.4.1
+    hardhat-contract-sizer: ^2.1.1
     lodash.frompairs: ^4.0.1
     lodash.pick: ^4.4.0
     lodash.range: ^3.2.0
@@ -4483,6 +4484,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cli-table3@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "cli-table3@npm:0.6.0"
+  dependencies:
+    colors: ^1.1.2
+    object-assign: ^4.1.0
+    string-width: ^4.2.0
+  dependenciesMeta:
+    colors:
+      optional: true
+  checksum: 4b61f9db4fb26039ab9299089d5a8a6a269f0d79eefd1e8b9479746f26ec186365bc6bf2bceb4812446cc213426b0f86cd86b7fc130a43d270d0f76e77f251f3
+  languageName: node
+  linkType: hard
+
 "cli-width@npm:^2.0.0":
   version: 2.2.1
   resolution: "cli-width@npm:2.2.1"
@@ -4585,6 +4600,13 @@ __metadata:
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: 3e1c9a4dee12eada307436f61614dd11fe300469db2b83f80c8b7a7cd8a1015f0f18dd13403f018927b249003777ff60baba4a03c65f12e6bddc0dfd9642021f
+  languageName: node
+  linkType: hard
+
+"colors@npm:^1.1.2, colors@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "colors@npm:1.4.0"
+  checksum: a0f266ac041a9774d92cc9624a984707678d2eeec125d54e8d8231075ce36c24c5352fb5d0f90c6ee420d0f63e354417cec716386ad341309334aad18e32b933
   languageName: node
   linkType: hard
 
@@ -7329,6 +7351,18 @@ fsevents@~2.1.1:
     ajv: ^6.12.3
     har-schema: ^2.0.0
   checksum: 01b905cdaa7632c926a962c8127a77b98387935ef3aa0b44dae871eae2592ba6da948a3bdbb3eeceb90fa1599300f16716e50147965a7ea7c4e7c4e57ac69727
+  languageName: node
+  linkType: hard
+
+"hardhat-contract-sizer@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "hardhat-contract-sizer@npm:2.1.1"
+  dependencies:
+    cli-table3: ^0.6.0
+    colors: ^1.4.0
+  peerDependencies:
+    hardhat: ^2.0.0
+  checksum: 901c01627466c6e025b178b3ad8ae2c4c430e6000bc78c124c7a849adaa831c69edfd9489a276f387e5b10b925adf3372f7e7a7ba49639d64148a04e91e710cc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reduction measures:
- two functions were removed
- library was declared external
- expensive (in terms of code size) operations, in particular thos that involve many memory arrays were moved to the library 
- require strings were removed, instead we use the balancer lightweight way of throwing error messages

Code Size: 23.3k kb(savings: 2-3k kb)

I commented out some currently unused functions in the test file, but left them there because we should still write some tests for which these funcitons might still be useful. I created an issue for this: https://github.com/PrimeDAO/balancer-v2-monorepo/issues/68

closes #67 